### PR TITLE
refactor: 💡 move actions around for convenience

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,8 +1,14 @@
 import Route from '@ember/routing/route';
 import I18nMixin from 'ember-i18next/mixins/i18n';
 import LngDetector from 'i18next-browser-languagedetector';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class ApplicationRoute extends Route.extend(I18nMixin) {
+
+  // =services
+
+  @service confirmations;
 
   // =methods
 
@@ -13,6 +19,27 @@ export default class ApplicationRoute extends Route.extend(I18nMixin) {
     super.beforeModel(...arguments);
     await this.i18n.i18next.use(LngDetector);
     return this.i18n.initLibraryAsync();
+  }
+
+  /**
+   * Requests abandon confirmation from user if record has changes.
+   * @param {Model} record
+   * @param {Transition} transition
+   */
+  @action
+  confirmAbandon(record, transition) {
+    /* istanbul ignore else  */
+    if (record.isDirty && !this.abandonConfirmation) {
+      transition.abort();
+      this.abandonConfirmation = this.confirmations.getConfirmation('abandon');
+      this.abandonConfirmation
+        .then(() => {
+          record.errors.clear();
+          record.rollback();
+          transition.retry();
+        })
+        .finally(() => delete this.abandonConfirmation);
+    }
   }
 
 }

--- a/app/routes/items.js
+++ b/app/routes/items.js
@@ -14,6 +14,7 @@ export default class ItemsRoute extends Route.extend(RealtimeRouteMixin) {
   // =services
 
   @service activePane;
+  @service confirmations;
 
   // =methods
 
@@ -30,6 +31,7 @@ export default class ItemsRoute extends Route.extend(RealtimeRouteMixin) {
 
   /**
    * Subscribe to realtime updates on items.
+   * @param {Object} model
    */
   afterModel(model) {
     this.subscribe(model.items);
@@ -55,6 +57,55 @@ export default class ItemsRoute extends Route.extend(RealtimeRouteMixin) {
   @action
   didTransition() {
     this.activePane.activateSidebar();
+  }
+
+  /**
+   * If dirty, valid, and not already saving, save the record.
+   * If save is successful, redirect to items.
+   * @param {Model} record
+   */
+  @action
+  async submit(record) {
+    // Only do save if the model has changes that are valid.
+    const canSave =
+      record.isDirty &&
+      record.validate() &&
+      !record.isSaving;
+
+    /* istanbul ignore else  */
+    if (canSave) {
+      await record.save();
+      this.transitionTo('items');
+    }
+  }
+
+  /**
+   * Clear errors, rollback attributes and relationships,
+   * and redirect to items route.  Redirect to items.
+   * @param {Model} record
+   */
+  @action
+  cancel(record) {
+    record.errors.clear();
+    record.rollback();
+    this.transitionTo('items');
+  }
+
+  /**
+   * Requests delete confirmation from user.  If confirmed, destroys
+   * record and redirects to items.
+   * @param {Model} record
+   */
+  @action
+  delete(record) {
+    /* istanbul ignore else  */
+    if (!this.deleteConfirmation) {
+      this.deleteConfirmation = this.confirmations.getConfirmation('delete');
+      this.deleteConfirmation
+        .then(() => record.destroyRecord())
+        .then(() => this.transitionTo('items'))
+        .finally(() => delete this.deleteConfirmation);
+    }
   }
 
 }

--- a/app/routes/items/item.js
+++ b/app/routes/items/item.js
@@ -30,4 +30,14 @@ export default class ItemsItemRoute extends Route {
   didTransition() {
     this.activePane.activateBody();
   }
+
+  /**
+   * Requests abandon confirmation from user if record has changes.
+   * @param {Transition} transition
+   */
+  @action
+  willTransition(transition) {
+    this.send('confirmAbandon', this.currentModel, transition);
+  }
+
 }

--- a/app/routes/items/item/index.js
+++ b/app/routes/items/item/index.js
@@ -1,15 +1,9 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 
 /**
  * Handles item persistence and post-persistence actions.
  */
 export default class ItemsItemIndexRoute extends Route {
-
-  // =services
-
-  @service confirmations;
 
   // =methods
 
@@ -22,71 +16,4 @@ export default class ItemsItemIndexRoute extends Route {
     controller.set('categories', this.modelFor('items').categories);
   }
 
-  // =actions
-
-  /**
-   * If dirty, valid, and not already saving, save the record.
-   * If save is successful, redirect to items.
-   */
-  @action
-  async submit() {
-    // Only do save if the model has changes that are valid.
-    const canSave =
-      this.currentModel.isDirty &&
-      this.currentModel.validate() &&
-      !this.currentModel.isSaving;
-
-    /* istanbul ignore else  */
-    if (canSave) {
-      await this.currentModel.save();
-      this.transitionTo('items');
-    }
-  }
-
-  /**
-   * Clear errors, rollback attributes and relationships,
-   * and redirect to items route.  Redirect to items.
-   */
-  @action
-  cancel() {
-    this.currentModel.errors.clear();
-    this.currentModel.rollback();
-    this.transitionTo('items');
-  }
-
-  /**
-   * Requests delete confirmation from user.  If confirmed, destroys
-   * record and redirects to items.
-   */
-  @action
-  delete() {
-    /* istanbul ignore else  */
-    if (!this.deleteConfirmation) {
-      this.deleteConfirmation = this.confirmations.getConfirmation('delete');
-      this.deleteConfirmation
-        .then(() => this.currentModel.destroyRecord())
-        .then(() => this.transitionTo('items'))
-        .finally(() => delete this.deleteConfirmation);
-    }
-  }
-
-  /**
-   * Requests abandon confirmation from user if record has changes.
-   * @param {Transition} transition
-   */
-  @action
-  willTransition(transition) {
-    /* istanbul ignore else  */
-    if (this.currentModel.isDirty && !this.abandonConfirmation) {
-      transition.abort();
-      this.abandonConfirmation = this.confirmations.getConfirmation('abandon');
-      this.abandonConfirmation
-        .then(() => {
-          this.currentModel.errors.clear();
-          this.currentModel.rollback();
-          transition.retry();
-        })
-        .finally(() => delete this.abandonConfirmation);
-    }
-  }
 }

--- a/app/templates/items/item/index.hbs
+++ b/app/templates/items/item/index.hbs
@@ -1,7 +1,7 @@
-<Form::Panel {{action "submit" on="submit"}} as |form panel|>
+<Form::Panel {{action "submit" @model on="submit"}} as |form panel|>
 
   <panel.header as |header|>
-    <form.cancel {{action "cancel"}}
+    <form.cancel {{action "cancel" @model}}
       disabled={{@model.isSaving}} />
     <header.title>{{@model.displayName}}</header.title>
     <form.save
@@ -35,7 +35,7 @@
       <form.delete
         @loading={{@model.isSaving}}
         disabled={{@model.isDirty}}
-        {{action "delete"}} />
+        {{action "delete" @model}} />
 
       <ListSet as |listSet|>
         {{#if this.categories}}

--- a/tests/unit/routes/items/item/index-test.js
+++ b/tests/unit/routes/items/item/index-test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { resolve } from 'rsvp';
 
 module('Unit | Route | items/item/index', function(hooks) {
   setupTest(hooks);
@@ -8,34 +7,5 @@ module('Unit | Route | items/item/index', function(hooks) {
   test('it exists', function(assert) {
     let route = this.owner.lookup('route:items/item/index');
     assert.ok(route);
-  });
-
-  test('it\'s submit action saves the record and redirects if dirty and valid and not saving', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('item', {name: 'Test'});
-    const route = this.owner.lookup('route:items/item/index');
-    assert.expect(5);
-    route.currentModel = model;
-    route.transitionTo = routeName => assert.equal(routeName, 'items');
-    model.save = () => {
-      assert.ok(true, 'model.save was called');
-      return resolve();
-    };
-    assert.ok(model.isDirty);
-    assert.ok(model.validate());
-    assert.notOk(model.isSaving);
-    route.submit();
-  });
-
-  test('it\'s cancel action cleans the record and redirects', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('item', {});
-    const route = this.owner.lookup('route:items/item/index');
-    assert.expect(3);
-    route.currentModel = model;
-    route.transitionTo = routeName => assert.equal(routeName, 'items');
-    assert.ok(model.isDirty);
-    route.cancel();
-    assert.ok(model.isClean);
   });
 });


### PR DESCRIPTION
We need to build a new item route, which has most persistence actions in
common with the item route.  We also need a generic abandon confirmation
action, as this function is needed across the app.